### PR TITLE
Corrected bug in parse.modal which was removing the rows without time…

### DIFF
--- a/server-reactives.R
+++ b/server-reactives.R
@@ -528,7 +528,7 @@ parse.modal <- reactive ({
   editSelectedCols()[time()],
   editSelectedCols()[outcome()])
   ## removes any null strings present in the rows of the data.frame
-  parse.modal <- parse.modal[!apply(parse.modal, 1, function(x) any(x=="")),] 
+  #parse.modal <- parse.modal[!apply(parse.modal, 1, function(x) any(x=="")),] 
   return(parse.modal)
 }) 
 

--- a/server.r
+++ b/server.r
@@ -103,6 +103,13 @@ shinyServer(function(input, output, session){
       output$SurvMessage <-renderText({""})
       output$kmSurvival <- renderPlot({
 
+      time = as.double(parse.modal()[,1])
+      outcome = as.integer(parse.modal()[,2])
+      x = x()
+        
+      save(time, outcome, x, file = "check.RData")
+        
+        
       return(plot.shiny.km(time = as.double(parse.modal()[,1]), 
                            death = as.integer(parse.modal()[,2]), 
                            x = x(), 


### PR DESCRIPTION
… and outcome information. We do NOT want to do this because the expression profiles for these samples are included in x(). I like the idea of not showing these samples in the modal window, but the corresponding NA values will still need to be returned by parse.modal.

To help debug this, I added some R code to save the current time, outcome, and x values whenever the km plot is generated. These are saved to a file called check.RData